### PR TITLE
Update instructions for recent perl releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,12 +35,11 @@ xnec2c-optimize is an optimization framework to tune antenna geometries with
 
 3. Install the dependencies with this command:
 
-       cpanm PDL::Opt::Simplex::Simple PDL::IO::CSV Linux::Inotify2 Time::HiRes
-
+       cpanm PDL::Opt::Simplex::Simple PDL::IO::CSV Linux::Inotify2 Time::HiRes Math::Vector::Real Math::Matrix
 
 4. See `yagi.conf` for an example to get started.   Just run this:
 
-       ./xnec2c-simplex.pl examples/yagi.conf 
+       ./xnec2c-simplex.pl ./examples/yagi.conf
 
 and then open `xnec2c -j NN examples/yagi.nec` where `NN` is the number of CPUs you
 have available on your system. 


### PR DESCRIPTION
A dot-slash is needed to avoid the following error from the commands given in the README file when using perl v5.34.

do "examples/yagi.conf" failed, '.' is no longer in @INC; did you mean do "./examples/yagi.conf"? at ./xnec2c-simplex.pl line 59.

Also add some missing module dependencies.